### PR TITLE
Allow Gradle to do Optimized Builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ dependencies {
 		exclude module: 'enigma'
 		exclude module: 'tiny-mappings-parser'
 	}
-	implementation ('com.github.Chocohead:Tiny-Mappings-Parser:d96d407') {
+	implementation ('com.github.calmilamsy:Tiny-Mappings-Parser:86ceccd') {
 		exclude module: 'sponge-mixin'
 	}
 	implementation ('com.github.Chocohead:OptiSine:cc6da75') {//Keep consistent with Openfine.VERSION

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ dependencies {
 		exclude module: 'enigma'
 		exclude module: 'tiny-mappings-parser'
 	}
-	implementation ('com.github.calmilamsy:Tiny-Mappings-Parser:86ceccd') {
+	implementation ('com.github.Chocohead:Tiny-Mappings-Parser:d96d407') {
 		exclude module: 'sponge-mixin'
 	}
 	implementation ('com.github.Chocohead:OptiSine:cc6da75') {//Keep consistent with Openfine.VERSION
@@ -69,7 +69,7 @@ dependencies {
 	}
 
 	// tinyfile management
-	implementation ('com.github.Chocohead:tiny-remapper:ab144ea') {
+	implementation ('com.github.Chocohead:tiny-remapper:b822055') {
 		transitive = false
 	}
 	compileOnly 'cuchaz:enigma:0.27.1'

--- a/src/main/java/net/fabricmc/loom/AbstractPlugin.java
+++ b/src/main/java/net/fabricmc/loom/AbstractPlugin.java
@@ -483,7 +483,12 @@ public class AbstractPlugin implements Plugin<Project> {
 						RemapSourcesJarTask remapSourcesJarTask = (RemapSourcesJarTask) project.getTasks().findByName("remapSourcesJar");
 						remapSourcesJarTask.setInput(sourcesTask.getArchivePath());
 						remapSourcesJarTask.setOutput(sourcesTask.getArchivePath());
-						remapSourcesJarTask.doLast(task -> project.getArtifacts().add("archives", remapSourcesJarTask.getOutput()));
+						remapSourcesJarTask.doLast(new Action<Task>() {
+							@Override
+							public void execute(Task task) {
+								project.getArtifacts().add("archives", remapSourcesJarTask.getOutput());
+							}
+						});
 						remapSourcesJarTask.dependsOn(project.getTasks().getByName("sourcesJar"));
 						project.getTasks().getByName("build").dependsOn(remapSourcesJarTask);
 					} catch (UnknownTaskException e) {

--- a/src/main/java/net/fabricmc/loom/AbstractPlugin.java
+++ b/src/main/java/net/fabricmc/loom/AbstractPlugin.java
@@ -192,7 +192,7 @@ public class AbstractPlugin implements Plugin<Project> {
 		configureCompile();
 		configureScala();
 
-		project.getTasks().withType(JavaCompile.class, javaCompileTask -> {
+		for (JavaCompile javaCompileTask : project.getTasks().withType(JavaCompile.class)) {
 			if (!javaCompileTask.getName().contains("Test") && !javaCompileTask.getName().contains("test")) {
 				//Allow adding extra mappings onto a compile for Mixin to generate remaps with
 				//The MinecraftVersion is not really relevant so we'll simplify things and pass null
@@ -309,7 +309,7 @@ public class AbstractPlugin implements Plugin<Project> {
 					javaCompileTask.getOptions().getCompilerArgs().add(arg.append('=').append(mappingFile.toAbsolutePath()).toString());
 				});
 			}
-		});
+		}
 
 		configureMaven();
 	}


### PR DESCRIPTION
Please merge, this halves build times on multi-module projects on newer Gradle versions.

Newer Gradle versions don't support optimizing lambda suppliers for tasks, so this PR nukes them and turns them into normal for loops and abstract implementations instead.